### PR TITLE
Integrating supervision annotators

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ requests
 rich
 torch
 torchvision
+supervision
 wandb

--- a/tests/test_tools/test_drawer.py
+++ b/tests/test_tools/test_drawer.py
@@ -1,8 +1,9 @@
 import sys
 from pathlib import Path
 
+import numpy as np
 from PIL import Image
-from torch import tensor
+import supervision as sv
 
 project_root = Path(__file__).resolve().parent.parent.parent
 sys.path.append(str(project_root))
@@ -24,6 +25,8 @@ def test_draw_model_by_model(model: YOLO):
 
 def test_draw_bboxes():
     """Test drawing bounding boxes on an image."""
-    predictions = tensor([[0, 60, 60, 160, 160, 0.5], [0, 40, 40, 120, 120, 0.5]])
+    detections = sv.Detections(xyxy=np.asarray([[60, 60, 160, 160], [40, 40, 120, 120]]),
+                               confidence=np.asarray([0.5, 0.5]),
+                               class_id=np.asarray([0, 0]))
     pil_image = Image.open("tests/data/images/train/000000050725.jpg")
-    draw_bboxes(pil_image, [predictions])
+    draw_bboxes(pil_image, detections)

--- a/tests/test_utils/test_model_utils.py
+++ b/tests/test_utils/test_model_utils.py
@@ -1,0 +1,21 @@
+from yolo.utils.model_utils import prediction_to_sv
+import torch
+import numpy as np
+
+
+def test_prediction_to_sv():
+
+    predictions = []
+    detections = prediction_to_sv(predictions)
+    assert len(detections) == 0
+
+    xyxy = torch.tensor([[60, 60, 160, 160], [40, 40, 120, 120]], dtype=torch.float32)
+    confidence = torch.tensor([0.5, 0.5], dtype=torch.float32).unsqueeze(1)
+    class_id = torch.tensor([0, 0], dtype=torch.int64).unsqueeze(1)
+    predictions = [torch.cat([class_id, xyxy, confidence], dim=1)]
+
+    detections = prediction_to_sv(predictions)
+    assert len(detections) == 2
+    assert np.allclose(detections.xyxy, xyxy.numpy())
+    assert np.allclose(detections.confidence, confidence.numpy().flatten())
+    assert np.allclose(detections.class_id, class_id.numpy().flatten())

--- a/yolo/__init__.py
+++ b/yolo/__init__.py
@@ -10,6 +10,7 @@ from yolo.utils.logging_utils import (
     YOLORichModelSummary,
     YOLORichProgressBar,
 )
+from yolo.utils.model_utils import prediction_to_sv
 from yolo.utils.model_utils import PostProcess
 
 all = [
@@ -30,4 +31,5 @@ all = [
     "FastModelLoader",
     "TrainModel",
     "PostProcess",
+    "prediction_to_sv",
 ]

--- a/yolo/tools/solver.py
+++ b/yolo/tools/solver.py
@@ -7,6 +7,7 @@ from torchmetrics.detection import MeanAveragePrecision
 from yolo.config.config import Config
 from yolo.model.yolo import create_model
 from yolo.tools.data_loader import create_dataloader
+from yolo.utils.model_utils import prediction_to_sv
 from yolo.tools.drawer import draw_bboxes
 from yolo.tools.loss_functions import create_loss_function
 from yolo.utils.bounding_box_utils import create_converter, to_metrics_format
@@ -126,7 +127,9 @@ class InferenceModel(BaseModel):
     def predict_step(self, batch, batch_idx):
         images, rev_tensor, origin_frame = batch
         predicts = self.post_process(self(images), rev_tensor=rev_tensor)
-        img = draw_bboxes(origin_frame, predicts, idx2label=self.cfg.dataset.class_list)
+        detections = prediction_to_sv(predicts)  # convert to sv format
+        class_list = [str(label) for label in self.cfg.dataset.class_list]
+        img = draw_bboxes(origin_frame, detections, idx2label=class_list)
         if getattr(self.predict_loader, "is_stream", None):
             fps = self._display_stream(img)
         else:

--- a/yolo/utils/model_utils.py
+++ b/yolo/utils/model_utils.py
@@ -12,6 +12,7 @@ from omegaconf import ListConfig
 from torch import Tensor, no_grad
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LambdaLR, SequentialLR, _LRScheduler
+import supervision as sv
 
 from yolo.config.config import IDX_TO_ID, NMSConfig, OptimizerConfig, SchedulerConfig
 from yolo.model.yolo import YOLO
@@ -222,3 +223,18 @@ def predicts_to_json(img_paths, predicts, rev_tensor):
             }
             batch_json.append(bbox)
     return batch_json
+
+
+def prediction_to_sv(predicts: List[Tensor]) -> sv.Detections:
+    """
+    Convert the prediction to the format of the Supervision
+    Args:
+        predicts:
+        rev_tensor:
+
+    Returns:
+        sv.Detections: The detections in the Supervision format
+    """
+    predicts = predicts[0].detach().cpu().numpy()
+    detections = sv.Detections(xyxy=predicts[:, 1:5], class_id=predicts[:, 0].astype(int), confidence=predicts[:, 5])
+    return detections

--- a/yolo/utils/model_utils.py
+++ b/yolo/utils/model_utils.py
@@ -235,6 +235,8 @@ def prediction_to_sv(predicts: List[Tensor]) -> sv.Detections:
     Returns:
         sv.Detections: The detections in the Supervision format
     """
+    if len(predicts) == 0:
+        return sv.Detections.empty()
     predicts = predicts[0].detach().cpu().numpy()
     detections = sv.Detections(xyxy=predicts[:, 1:5], class_id=predicts[:, 0].astype(int), confidence=predicts[:, 5])
     return detections


### PR DESCRIPTION
This PR introduces converting predicitons to `supervision.Detections` format which can be directly useful to create different visual annotations. Further detections can be directly useful for some of the post process steps e.g. combining multiple predictions and some of the dataset utilities. 

Ref: 
https://supervision.roboflow.com/latest/detection/core/
https://supervision.roboflow.com/latest/detection/annotators/


Sample output:
![frame001](https://github.com/user-attachments/assets/02190aee-d49c-4204-8adb-527ae38f47e5)

