### PR TITLE
Multi-GPU training error

### DIFF
--- a/yolo/utils/logging_utils.py
+++ b/yolo/utils/logging_utils.py
@@ -317,7 +317,6 @@ def log_model_structure(model: Union[ModuleList, YOLOLayer, YOLO]):
     console.print(table)
 
 
-@rank_zero_only
 def validate_log_directory(cfg: Config, exp_name: str) -> Path:
     base_path = Path(cfg.out_path, cfg.task.task)
     save_path = base_path / exp_name


### PR DESCRIPTION
if not remove the decorator `rank_zero_only`, it will encounter an error as shown below, when the users use multi-gpu training.
```
Traceback (most recent call last):
  File "/media/user/disk2/mateo/ramen/YOLO-mainz/yolo/lazy.py", line 17, in main
    callbacks, loggers, save_path = setup(cfg)
  File "/media/user/disk2/mateo/ramen/YOLO-mainz/yolo/utils/logging_utils.py", line 286, in setup
    loggers.append(TensorBoardLogger(log_graph="all", save_dir=save_path))
  File "/media/user/disk2/mateo/py310_venv/sushilon/lib/python3.10/site-packages/lightning/pytorch/loggers/tensorboard.py", line 96, in __init__
    super().__init__(
  File "/media/user/disk2/mateo/py310_venv/sushilon/lib/python3.10/site-packages/lightning/fabric/loggers/tensorboard.py", line 98, in __init__
    root_dir = os.fspath(root_dir)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```  